### PR TITLE
Workaround for PHP-Bug in date calculations (used in statistics)

### DIFF
--- a/opt/gemeinschaft/htdocs/gui/mod/stats_groupc.php
+++ b/opt/gemeinschaft/htdocs/gui/mod/stats_groupc.php
@@ -139,7 +139,7 @@ foreach ($group_info AS $group_select) {
 <label for="ipt-month"><?php echo __('Monat'); ?>:</label>
 <select name="month" id="ipt-month">
 <?php
-$t = time();
+$t = mktime(0,0,0,date("n"),1,date("Y"));
 for ($i=-3; $i<=0; ++$i) {
 	echo '<option value="',$i,'"', ($i==$month_d ? ' selected="selected"' : ''),'>', date('m / Y', (int)strToTime("$i months", $t)) ,'</option>' ,"\n";
 }

--- a/opt/gemeinschaft/htdocs/gui/mod/stats_groupout.php
+++ b/opt/gemeinschaft/htdocs/gui/mod/stats_groupout.php
@@ -146,7 +146,7 @@ foreach ($group_info AS $group_select) {
 <label for="ipt-month"><?php echo __('Monat'); ?>:</label>
 <select name="month" id="ipt-month">
 <?php
-$t = time();
+$t = mktime(0,0,0,date("n"),1,date("Y"));
 for ($i=-3; $i<=0; ++$i) {
 	echo '<option value="',$i,'"', ($i==$month_d ? ' selected="selected"' : ''),'>', date('m / Y', (int)strToTime("$i months", $t)) ,'</option>' ,"\n";
 }

--- a/opt/gemeinschaft/htdocs/gui/mod/stats_qclassical.php
+++ b/opt/gemeinschaft/htdocs/gui/mod/stats_qclassical.php
@@ -102,7 +102,7 @@ if (count($queue_groups) > 0) {
 <label for="ipt-month"><?php echo __('Monat'); ?>:</label>
 <select name="month" id="ipt-month">
 <?php
-$t = time();
+$t = mktime(0,0,0,date("n"),1,date("Y"));
 for ($i=-3; $i<=0; ++$i) {
 	echo '<option value="',$i,'"', ($i==$month_d ? ' selected="selected"' : ''),'>', date('m / Y', (int)strToTime("$i months", $t)) ,'</option>' ,"\n";
 }


### PR DESCRIPTION
Das Problem tritt bei der Erstellung der Liste Monate für die Statistik auf (aktueller Monat und die drei vorigen).

strToTime("-1 months", time()); liefert z.B. am 31.10. den 1.10. und nicht wie gewünscht den 30.9.

Fehlerumgehung daher: anstatt time() den ersten des aktuellen Monats als Basis für die Berechnung / Erstellung  der Liste nehmen.
