### PR TITLE
Add Phonesuite provisioning

### DIFF
--- a/etc/gemeinschaft/gemeinschaft.php
+++ b/etc/gemeinschaft/gemeinschaft.php
@@ -504,6 +504,29 @@ $POLYCOM_PROV_ALLOW_LOG_PUT  = false;
   # allow Polycom phones to PUT their logs to Apache
 
 
+//---------------------[ Phonesuite ]--------------------//
+
+$PHONESUITE_PROV_ENABLED      = false;  # do provisioning for Phonesuite?
+
+#$PHONESUITE_PROV_HOST         = '';
+  # The hostname or IP which is reachable by the phonesuite
+  # (default: PROV_HOST)
+
+$PHONESUITE_PROV_AMI_USERNAME = 'phonesuite';
+$PHONESUITE_PROV_AMI_SECRET   = 'gEheiM23y89sdo23';
+  # asterisk manager login data.
+  # see GUI -> Administration -> Asterisk Manager for configuration details
+
+$PHONESUITE_PROV_AUTO_ANSWER_MODE = 0;
+  # 0 = PBX calls phone and connects after pickup
+  # > 1 Phone directly starts a call without user intervention
+  # 1 = Default behavior
+  # 3 = Snom behaviour
+  
+#$PHONESUITE_PROV_LICENSEKEY   = 'XXXXXX-XXXXXX-XXXXXX';
+#$PHONESUITE_PROV_LICENSEE     = 'My Company';
+  # set these variables if you want to provision your license as well
+  # set to null if you dont want this
 
 /***********************************************************
 *    CANONICAL PHONE NUMBERS (FQTN)

--- a/opt/gemeinschaft/htdocs/gui/img/.gitignore
+++ b/opt/gemeinschaft/htdocs/gui/img/.gitignore
@@ -1,0 +1,1 @@
+/phonesuite.ico

--- a/opt/gemeinschaft/htdocs/gui/mod/home_home.php
+++ b/opt/gemeinschaft/htdocs/gui/mod/home_home.php
@@ -316,6 +316,20 @@ LIMIT 5'
 			<img alt="<?php echo htmlEnt(__("w\xC3\xA4hlen")); ?>" src="<?php echo GS_URL_PATH, 'crystal-svg/16/app/yast_PhoneTTOffhook.png'; ?>" style="margin:0 5px;" />
 			</button>
 			</form>
+
+			<?php if(gs_get_conf('GS_PHONESUITE_PROV_ENABLED')) { ?>
+			<hr />
+			<?php if(!file_exists('/opt/gemeinschaft/htdocs/gui/img/phonesuite.ico')) { ?>
+			<p>Please save an icon for the phonesuite button to /opt/gemeinschaft/htdocs/gui/img/phonesuite.ico. You may take the Phonesuite icon from PhoneSuite_TAPI_for_Asterisk_setup.zip/bin/prog.ico</p>
+			<?php } ?>
+			<form method="get" action="<?php echo GS_URL_PATH, 'prov/phonesuite/settings.php' ?>">
+			<?php echo gs_form_hidden($SECTION, $MODULE); ?>
+			<button class="m" title="<?php echo __("PhoneSuite-Profil herunterladen"); ?>" style="height:22px; padding:0;">
+			<img alt="<?php echo __("PhoneSuite-Profil herunterladen"); ?>" src="<?php echo GS_URL_PATH, 'img/phonesuite.ico'; ?>" style="margin:0 5px;" />
+			<?php echo __("PhoneSuite-Profil herunterladen"); ?>
+			</button>
+			</form>
+			<?php } ?>
 		</div>
 
 		<div class="th" style="padding:0.35em 0.5em; margin-bottom:2px;">

--- a/opt/gemeinschaft/htdocs/prov/phonesuite/index.html
+++ b/opt/gemeinschaft/htdocs/prov/phonesuite/index.html
@@ -1,0 +1,1 @@
+Nothing to see here. Move along.

--- a/opt/gemeinschaft/htdocs/prov/phonesuite/settings.php
+++ b/opt/gemeinschaft/htdocs/prov/phonesuite/settings.php
@@ -1,0 +1,140 @@
+<?php
+/*******************************************************************\
+*            Gemeinschaft - asterisk cluster gemeinschaft
+* 
+* $Revision$
+* 
+* Copyright 2007, amooma GmbH, Bachstr. 126, 56566 Neuwied, Germany,
+* http://www.amooma.de/
+* Stefan Wintermeyer <stefan.wintermeyer@amooma.de>
+* Philipp Kempgen <philipp.kempgen@amooma.de>
+* Peter Kozak <peter.kozak@amooma.de>
+* 
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+* 
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+* 
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+* MA 02110-1301, USA.
+\*******************************************************************/
+
+# have a look at
+# http://phonesuite.de/hlp/de/ast/ast/auto_configuration.htm
+
+define( 'GS_VALID', true );  /// this is a parent file
+
+header( 'Expires: 0' );
+header( 'Pragma: no-cache' );
+header( 'Cache-Control: private, no-cache, must-revalidate' );
+header( 'Vary: *' );
+
+
+require_once( dirName(__FILE__) .'/../../../inc/conf.php' );
+require_once( GS_DIR .'inc/util.php' );
+require_once( GS_DIR .'inc/gs-lib.php' );
+require_once( GS_DIR .'inc/prov-fns.php' );
+set_error_handler('err_handler_die_on_err');
+
+if (! gs_get_conf('GS_PHONESUITE_PROV_ENABLED')) {
+	gs_log( GS_LOG_DEBUG, "Phonesuite provisioning not enabled" );
+	_settings_err( 'Not enabled.' );
+}
+
+
+function build_taco_string($assoc_arr) { 
+	$content = ""; 
+	foreach ($assoc_arr as $key=>$elem) { 
+		$content .= "[".$key."]\n"; 
+		foreach ($elem as $key2=>$elem2) { 
+			if(is_array($elem2)) 
+			{ 
+				for($i=0;$i<count($elem2);$i++) 
+				{ 
+					$content .= $key2."[]=".$elem2[$i]."\n"; 
+				} 
+			} 
+			else if($elem2==="") $content .= $key2."=\n"; 
+			else $content .= $key2."=".$elem2."\n"; 
+		} 
+	} 
+
+	return $content;
+}
+
+
+require_once( GS_DIR .'inc/db_connect.php' );
+
+
+$db = gs_db_master_connect();
+if (! $db) {
+	gs_log( GS_LOG_WARNING, "Phonesuite asks for settings - Could not connect to DB" );
+	_settings_err( 'Could not connect to DB.' );
+}
+
+# is it a valid user?
+#
+$user = @$_REQUEST['user'] ? @$_REQUEST['user'] : @$_REQUEST['sudo'];
+$user_id = (int)$db->executeGetOne( 'SELECT `id` FROM `users` WHERE `user`="'. $user .'"' );
+if ($user_id < 1)
+	$user_id = 0;
+
+if ($user_id < 1) {
+	die("User " . $user . " does not exist");
+}
+
+# get host for user
+#
+$host = @gs_prov_get_host_for_user_id( $db, $user_id );
+if (! $host) {
+	_settings_err( 'Failed to find host.' );
+}
+$pbx = $host;  # $host might be changed if SBC configured
+
+
+# who is requesting configuration?
+#
+$user = @gs_prov_get_user_info( $db, $user_id );
+if (! is_array($user)) {
+	_settings_err( 'DB error.' );
+}
+
+
+#####################################################################
+#  General
+#####################################################################
+
+$settings = Array(
+	'AsteriskServer_IP' 		=> gs_get_conf('GS_PHONESUITE_PROV_HOST'),
+	'AsteriskServer_Username'	=> gs_get_conf('GS_PHONESUITE_PROV_AMI_USERNAME'),
+	'AsteriskServer_Pwd'		=> gs_get_conf('GS_PHONESUITE_PROV_AMI_SECRET'),
+	'AsteriskLine_Channel'		=> 'SIP/' . $user['name'],
+	'AsteriskLine_PhoneNumber'	=> $user['name'],
+	'AsteriskLine_Username'		=> $user['callerid'],
+	'AsteriskLine_AutoAnswerMode'	=> gs_get_conf('GS_PHONESUITE_PROV_AUTO_ANSWER_MODE', 0),
+);
+
+if(gs_get_conf('GS_PHONESUITE_PROV_LICENSEKEY') !== null) {
+	$settings = array_merge($settings, Array(
+		'LicenseKey'			=> gs_get_conf('GS_PHONESUITE_PROV_LICENSEKEY'),
+		'LicenseeName'			=> gs_get_conf('GS_PHONESUITE_PROV_LICENSEE'),
+	));
+}
+
+$output = build_taco_string(Array('ALL' => $settings), true);
+
+header( 'Content-Type: text/x-ini' );
+header( 'Content-Disposition: attachment;filename=phonesuite-config-'. $user['user'] .'.taco' );
+print $output;
+
+unset($output);
+unset($settings);
+
+?>

--- a/opt/gemeinschaft/inc/conf.php
+++ b/opt/gemeinschaft/inc/conf.php
@@ -325,6 +325,14 @@ _gscnf( 'TIPTEL_PROV_FW_DEFAULT_IP284' , null            );
 _gscnf( 'TIPTEL_PROV_FW_DEFAULT_IP286' , null            );
 _gscnf( 'TIPTEL_PROV_KEY_BLACKLIST' , ''                 );
 
+_gscnf( 'PHONESUITE_PROV_ENABLED'          , false       );
+_gscnf( 'PHONESUITE_PROV_HOST'             , gs_get_conf('GS_PROV_HOST',''));
+_gscnf( 'PHONESUITE_PROV_AMI_USERNAME'     , ''          );
+_gscnf( 'PHONESUITE_PROV_AMI_SECRET'       , ''          );
+_gscnf( 'PHONESUITE_PROV_AUTO_ANSWER_MODE' , 0           );
+_gscnf( 'PHONESUITE_PROV_LICENSEKEY'       , null        );
+_gscnf( 'PHONESUITE_PROV_LICENSEE'         , null        );
+
 _gscnf( 'CANONIZE_OUTBOUND'         , true               );
 _gscnf( 'CANONIZE_INTL_PREFIX'      , '00'               );
 _gscnf( 'CANONIZE_COUNTRY_CODE'     , '49'               );


### PR DESCRIPTION
This PR generates autoconfiguration files for PhoneSuite for users. The autoconfiguration file can be downloaded by the user from the GS "home" page or directly via "/gemeinschaft/prov/phonesuite/settings.php?user=<username>" (without authentication, for auto-deployment)

The button on the homepage comes without an icon. The admin may get an icon from PhoneSuite_TAPI_for_Asterisk_setup.zip/bin/prog.ico. The path where to put it is shown on the homepage when no icon is present. This is to make sure that I add no license violations.
