### PR TITLE
install.sh: fix link to latest asterisk-1.8 release

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -308,9 +308,9 @@ make config
 dahdi_genconf || true
 
 cd /usr/local/src/
-$DOWNLOAD "http://downloads.asterisk.org/pub/telephony/asterisk/asterisk-1.8-current.tar.gz"
-tar -xvzf asterisk-1.8-current.tar.gz
-cd $(tar -tzf asterisk-1.8-current.tar.gz | head -n 1 | cut -d '/' -f1)
+$DOWNLOAD "http://downloads.asterisk.org/pub/telephony/asterisk/releases/asterisk-1.8.32.3.tar.gz"
+tar -xvzf asterisk-1.8.32.3.tar.gz
+cd $(tar -tzf asterisk-1.8.32.3.tar.gz | head -n 1 | cut -d '/' -f1)
 ./configure
 make menuselect.makeopts
 menuselect/menuselect --enable res_config_mysql menuselect.makeopts


### PR DESCRIPTION
from `asterisk-1.8-current` to `asterisk-1.8.32.3` (released 08-Apr-2015)
see #42